### PR TITLE
Shade snakeyaml 1.20 due to bungee/spigot bump

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,6 +92,14 @@ subprojects {
 
             relocate("org.ocpsoft.prettytime", "net.minecrell.serverlistplus.core.lib.prettytime")
         }
+
+        if (project.name == "Bungee" || project.name == "Bukkit") {
+            // Broken as of 1.20 (https://github.com/SpigotMC/BungeeCord/blame/master/config/pom.xml#L32)
+            dependencies {
+                include(dependency("org.yaml:snakeyaml"))
+            }
+            relocate("org.yaml.snakeyaml", "net.minecrell.serverlistplus.snakeyaml")
+        }
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/Minebench/ServerListPlus/issues/2

Bungee and Spigot have bumped snakeyaml to 2.0 which has breaking changes, so this is needed to work with 1.20 while maintaining compatibility with pre-1.20 platforms.